### PR TITLE
Updated httpd.rb to use correct libxml2

### DIFF
--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -63,6 +63,7 @@ class Httpd < Formula
                           "--with-nghttp2=#{Formula["nghttp2"].opt_prefix}",
                           "--with-ssl=#{Formula["openssl"].opt_prefix}",
                           "--with-pcre=#{Formula["pcre"].opt_prefix}",
+                          "--with-libxml2=#{Formula["libxml2"].opt_prefix}",
                           "--disable-lua",
                           "--disable-luajit"
     system "make"


### PR DESCRIPTION
httpd.rb was always using the system's libxml2 during ./configure instead of the version installed by homebrew.
Fixes https://github.com/Linuxbrew/homebrew-core/issues/9205